### PR TITLE
Add LLM summary service

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ env bash -c "$(curl -sL https://github.com/telekom-security/tpotce/raw/master/in
   - [Kibana Dashboard](#kibana-dashboard)
   - [Attack Map](#attack-map)
   - [Cyberchef](#cyberchef)
+  - [LLM Summary](#llm-summary)
   - [Elasticvue](#elasticvue)
   - [Spiderfoot](#spiderfoot)
 - [Configuration](#configuration)
@@ -187,6 +188,7 @@ T-Pot offers a number of services which are basically divided into five groups:
     * Elasticvue a web front end for browsing and interacting with an Elasticsearch cluster.
     * T-Pot Attack Map a beautifully animated attack map for T-Pot.
     * Spiderfoot an open source intelligence automation tool.
+    * LLM Summary provides a short textual overview of recent honeypot attacks.
 4. Honeypots
     * A selection of the 23 available honeypots based on the selected `docker-compose.yml`.
 5. Network Security Monitoring (NSM)
@@ -206,6 +208,7 @@ During the installation and during the usage of T-Pot there are two different ty
 | Elasticvue       | BasicAuth    | `<WEB_USER>`     | `<web_user>` you chose during the installation of T-Pot.           |
 | Geoip Attack Map | BasicAuth    | `<WEB_USER>`     | `<web_user>` you chose during the installation of T-Pot.           |
 | Spiderfoot       | BasicAuth    | `<WEB_USER>`     | `<web_user>` you chose during the installation of T-Pot.           |
+| LLM Summary     | BasicAuth    | `<WEB_USER>`     | `<web_user>` you chose during the installation of T-Pot.           |
 | T-Pot            | OS           | `tpot`           | `tpot` this user / group is always reserved by the T-Pot services. |
 | T-Pot Logs       | BasicAuth    | `<LS_WEB_USER>`  | `LS_WEB_USER` are automatically managed.                           |
 
@@ -571,6 +574,11 @@ On the T-Pot Landing Page just click on `Attack Map` and you will be forwarded t
 
 ![AttackMap](doc/attackmap.png)
 <br><br>
+## LLM Summary
+On the T-Pot Landing Page click on `LLM Summary` to retrieve a two-paragraph digest of recent honeypot activity.
+This feature requires the LLM honeypots and a working Ollama or ChatGPT setup.
+
+<br><br>
 
 ## Cyberchef
 On the T-Pot Landing Page just click on `Cyberchef` and you will be forwarded to Cyberchef.
@@ -612,6 +620,8 @@ tarpit.yml
 tpot_services.yml
 ```
 The `.yml` files are docker compose files, each representing a different set of honeypots and tools with `tpot_services.yml` being a template for `customizer.py` to create a customized docker compose file.<br><br>
+The `llm.yml` compose file also contains the optional LLM summary service. Ensure your Ollama or ChatGPT credentials are set in `~/tpotce/.env` before enabling it.
+
 To activate a compose file follow these steps:
 1. Stop T-Pot with `systemctl stop tpot`.
 2. Copy the docker compose file `cp ~/tpotce/compose/<dockercompose.yml> ~/tpotce/docker-compose.yml`.

--- a/compose/llm.yml
+++ b/compose/llm.yml
@@ -348,3 +348,23 @@ services:
     pull_policy: ${TPOT_PULL_POLICY}
     volumes:
      - ${TPOT_DATA_PATH}/spiderfoot:/home/spiderfoot/.spiderfoot
+
+# LLM Summary service
+  llm_summary:
+    container_name: llm_summary
+    restart: always
+    depends_on:
+      map_data:
+        condition: service_started
+    networks:
+     - nginx_local
+    ports:
+     - "127.0.0.1:65432:8000"
+    image: ${TPOT_REPO}/llm_summary:${TPOT_VERSION}
+    pull_policy: ${TPOT_PULL_POLICY}
+    environment:
+      LLM_PROVIDER: ${LLM_SUMMARY_PROVIDER}
+      LLM_SERVER_URL: ${LLM_SUMMARY_SERVER_URL}
+      LLM_MODEL: ${LLM_SUMMARY_MODEL}
+      LLM_API_KEY: ${LLM_SUMMARY_API_KEY}
+      MAP_DATA_URL: http://map_data:64299

--- a/docker/llm_summary/Dockerfile
+++ b/docker/llm_summary/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /opt/llm_summary
+COPY llm_summary.py ./
+RUN pip install --no-cache-dir flask requests geoip2
+EXPOSE 8000
+CMD ["python", "llm_summary.py"]

--- a/docker/llm_summary/docker-compose.yml
+++ b/docker/llm_summary/docker-compose.yml
@@ -1,0 +1,17 @@
+networks:
+  llm_summary_local:
+
+services:
+  llm_summary:
+    build: .
+    container_name: llm_summary
+    restart: always
+    networks:
+      - llm_summary_local
+    ports:
+      - "127.0.0.1:65432:8000"
+    environment:
+      LLM_PROVIDER: "ollama"
+      LLM_SERVER_URL: "http://ollama.local:11434"
+      LLM_MODEL: "llama3.1"
+    image: "dtagdevsec/llm_summary:24.04"

--- a/docker/llm_summary/llm_summary.py
+++ b/docker/llm_summary/llm_summary.py
@@ -1,0 +1,84 @@
+import os
+import requests
+import geoip2.database
+from flask import Flask, Response
+
+MAP_DATA_URL = os.getenv("MAP_DATA_URL", "http://map_data:64299")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "ollama")
+LLM_SERVER_URL = os.getenv("LLM_SERVER_URL", "http://ollama:11434")
+LLM_MODEL = os.getenv("LLM_MODEL", "llama3")
+LLM_API_KEY = os.getenv("LLM_API_KEY")
+GEOIP_DB_PATH = os.getenv("GEOIP_DB_PATH", "/usr/share/GeoIP/GeoLite2-City.mmdb")
+EVENT_LIMIT = int(os.getenv("EVENT_LIMIT", "20"))
+PORT = int(os.getenv("PORT", "8000"))
+
+app = Flask(__name__)
+
+
+def fetch_events():
+    try:
+        r = requests.get(f"{MAP_DATA_URL}/events?limit={EVENT_LIMIT}", timeout=10)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return []
+
+
+def geolocate(ip, reader):
+    try:
+        response = reader.city(ip)
+        city = response.city.name or ""
+        country = response.country.iso_code or ""
+        return ", ".join(filter(None, [city, country]))
+    except Exception:
+        return "unknown"
+
+
+def build_prompt(events):
+    lines = []
+    for e in events:
+        ip = e.get("src_ip") or e.get("ip")
+        geo = e.get("geo", "")
+        attack = e.get("attack") or e.get("type")
+        lines.append(f"{ip} ({geo}) - {attack}")
+    joined = "\n".join(lines)
+    return (
+        "Summarize the following honeypot events in two short paragraphs:\n" + joined
+    )
+
+
+def query_llm(prompt):
+    if LLM_PROVIDER.lower() == "ollama":
+        payload = {"model": LLM_MODEL, "prompt": prompt}
+        r = requests.post(f"{LLM_SERVER_URL}/api/generate", json=payload, timeout=30)
+        return r.json().get("response", "")
+    else:
+        headers = {"Authorization": f"Bearer {LLM_API_KEY}"}
+        data = {
+            "model": LLM_MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        r = requests.post(
+            f"{LLM_SERVER_URL}/v1/chat/completions",
+            headers=headers,
+            json=data,
+            timeout=30,
+        )
+        return r.json()["choices"][0]["message"]["content"]
+
+
+@app.route("/summary")
+def summary():
+    events = fetch_events()
+    reader = geoip2.database.Reader(GEOIP_DB_PATH)
+    for e in events:
+        ip = e.get("src_ip") or e.get("ip")
+        e["geo"] = geolocate(ip, reader)
+    prompt = build_prompt(events)
+    result = query_llm(prompt)
+    return Response(result, mimetype="text/plain")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=PORT)
+

--- a/env.example
+++ b/env.example
@@ -143,6 +143,16 @@ GALAH_LLM_SERVER_URL: "http://ollama.local:11434"
 GALAH_LLM_MODEL: "llama3.1"
 
 
+# LLM Summary Service
+# LLM_SUMMARY_PROVIDER: Set to "ollama" or "gpt4-o".
+# LLM_SUMMARY_SERVER_URL: URL of your LLM backend.
+# LLM_SUMMARY_MODEL: Name of the model served by your backend.
+# LLM_SUMMARY_API_KEY: API key for ChatGPT (optional).
+LLM_SUMMARY_PROVIDER: "ollama"
+LLM_SUMMARY_SERVER_URL: "http://ollama.local:11434"
+LLM_SUMMARY_MODEL: "llama3.1"
+LLM_SUMMARY_API_KEY: ""
+
 ###################################################################################
 # NEVER MAKE CHANGES TO THIS SECTION UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!!! #
 ###################################################################################

--- a/scripts/llm_summary.py
+++ b/scripts/llm_summary.py
@@ -1,0 +1,84 @@
+import os
+import requests
+import geoip2.database
+from flask import Flask, Response
+
+MAP_DATA_URL = os.getenv("MAP_DATA_URL", "http://map_data:64299")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "ollama")
+LLM_SERVER_URL = os.getenv("LLM_SERVER_URL", "http://ollama:11434")
+LLM_MODEL = os.getenv("LLM_MODEL", "llama3")
+LLM_API_KEY = os.getenv("LLM_API_KEY")
+GEOIP_DB_PATH = os.getenv("GEOIP_DB_PATH", "/usr/share/GeoIP/GeoLite2-City.mmdb")
+EVENT_LIMIT = int(os.getenv("EVENT_LIMIT", "20"))
+PORT = int(os.getenv("PORT", "8000"))
+
+app = Flask(__name__)
+
+
+def fetch_events():
+    try:
+        r = requests.get(f"{MAP_DATA_URL}/events?limit={EVENT_LIMIT}", timeout=10)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return []
+
+
+def geolocate(ip, reader):
+    try:
+        response = reader.city(ip)
+        city = response.city.name or ""
+        country = response.country.iso_code or ""
+        return ", ".join(filter(None, [city, country]))
+    except Exception:
+        return "unknown"
+
+
+def build_prompt(events):
+    lines = []
+    for e in events:
+        ip = e.get("src_ip") or e.get("ip")
+        geo = e.get("geo", "")
+        attack = e.get("attack") or e.get("type")
+        lines.append(f"{ip} ({geo}) - {attack}")
+    joined = "\n".join(lines)
+    return (
+        "Summarize the following honeypot events in two short paragraphs:\n" + joined
+    )
+
+
+def query_llm(prompt):
+    if LLM_PROVIDER.lower() == "ollama":
+        payload = {"model": LLM_MODEL, "prompt": prompt}
+        r = requests.post(f"{LLM_SERVER_URL}/api/generate", json=payload, timeout=30)
+        return r.json().get("response", "")
+    else:
+        headers = {"Authorization": f"Bearer {LLM_API_KEY}"}
+        data = {
+            "model": LLM_MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        r = requests.post(
+            f"{LLM_SERVER_URL}/v1/chat/completions",
+            headers=headers,
+            json=data,
+            timeout=30,
+        )
+        return r.json()["choices"][0]["message"]["content"]
+
+
+@app.route("/summary")
+def summary():
+    events = fetch_events()
+    reader = geoip2.database.Reader(GEOIP_DB_PATH)
+    for e in events:
+        ip = e.get("src_ip") or e.get("ip")
+        e["geo"] = geolocate(ip, reader)
+    prompt = build_prompt(events)
+    result = query_llm(prompt)
+    return Response(result, mimetype="text/plain")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=PORT)
+


### PR DESCRIPTION
## Summary
- add LLM summary Flask app with GeoIP and LLM API support
- create llm_summary container build files
- expose new `llm_summary` service in `compose/llm.yml`
- document configuration variables and usage in README
- update env.example with default variables

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6859b3ffbc008322b0205a5ddec8c6ef